### PR TITLE
Add 'sentences' and 'tokens' to the tables that can be exported

### DIFF
--- a/src/screens/adminScreens/ExportDataScreen.tsx
+++ b/src/screens/adminScreens/ExportDataScreen.tsx
@@ -8,6 +8,8 @@ import FunctionButton from 'components/FunctionButton';
 const tableDescriptions = {
   users: "Utilisateurs de l'application",
   texts: "Table des textes",
+  sentences: "Table des phrases issues des textes",
+  tokens: "Table des tokens (attention: le fichier peut être volumineux)",
   user_text_rating: "Annotations individuelles de plausibilité dans MythoOuPas",
   group_text_rating: "Groupe d'annotations de plausibilité dans MythoOuPas",
   user_sentence_specification: "Annotations de négations dans MythoNo",
@@ -38,6 +40,8 @@ const ExportDataScreen = () => {
   const [selectedTables, setSelectedTables] = useState({
     users: false,
     texts: false,
+    sentences: false,
+    tokens: false,
     user_text_rating: false,
     group_text_rating: false,
     user_error_details: false,


### PR DESCRIPTION
The `sentences` and `tokens` tables could not be exported using the UI. I was able to circumvent this by manually crafting the POST request, but this requires technical knowledge some members of the team don't have.

This PR adds the `sentences` and `tokens` tables to the `ExportData` page of the admin dashboard.

This was tested locally, as the screenshot shows:

![image](https://github.com/user-attachments/assets/c3511d93-f1ee-4864-885f-f44ac04830b9)
